### PR TITLE
Update default OpenAI model to gpt-5-mini and add config defaults sys…

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -6,7 +6,7 @@ max_requests_per_minute = 1000
 [OpenAI]
 # OpenAI API configuration for song extraction
 api_key = your-openai-api-key
-model = gpt-5
+model = gpt-5-mini
 
 [Spotify]
 # Spotify API credentials
@@ -28,7 +28,7 @@ request_overlay_duration = 10
 [OBS]
 # OBS WebSocket configuration
 enabled = true
-host = localhost
+host = 127.0.0.1
 port = 4455
 password = your-obs-password
 


### PR DESCRIPTION
…tem to setup wizard

Change default OpenAI model from gpt-5 to gpt-5-mini in config.ini.example and SetupPage. Update OBS host from localhost to 127.0.0.1 in example config. Add DEFAULT_CFG constant and withDefaults helper to populate missing config values with sensible defaults (Spotify redirect_url, Events API max_requests_per_minute, OpenAI model, General request_overlay_duration). Apply defaults when loading config and initial