### PR TITLE
Add queue state overlay triggers and paused banner to Dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -1476,14 +1476,26 @@ class SongRequestService:
             return False
         if not hasattr(self.actions, 'auto_dj'):
             return False
-        return bool(self.actions.auto_dj.pause_queue())
+        ok = bool(self.actions.auto_dj.pause_queue())
+        if ok:
+            try:
+                await self.actions.trigger_queue_state_overlay("Queue Paused")
+            except Exception:
+                pass
+        return ok
 
     async def resume_queue(self) -> bool:
         if not getattr(self.actions, 'chatdj_enabled', False):
             return False
         if not hasattr(self.actions, 'auto_dj'):
             return False
-        return bool(self.actions.auto_dj.unpause_queue())
+        ok = bool(self.actions.auto_dj.unpause_queue())
+        if ok:
+            try:
+                await self.actions.trigger_queue_state_overlay("Queue Resumed")
+            except Exception:
+                pass
+        return ok
 
     async def move_queue_item(self, from_index: int, to_index: int) -> bool:
         if not getattr(self.actions, 'chatdj_enabled', False):

--- a/handlers/obshandler.py
+++ b/handlers/obshandler.py
@@ -696,7 +696,7 @@ class OBSHandler:
                         })
 
             request_content = {
-                'inputName': 'MotorOverlay',  # Make sure this matches your OBS text source name
+                'inputName': 'GeneralOverlay',  # Make sure this matches your OBS text source name
                 'inputSettings': {
                     'text': message
                 }
@@ -714,7 +714,7 @@ class OBSHandler:
 
             await asyncio.sleep(1)
 
-            visibility_success = await self.set_source_visibility('main', 'MotorOverlay', True)
+            visibility_success = await self.set_source_visibility('main', 'GeneralOverlay', True)
 
             if text_success and visibility_success:
                 logger.info("obs.overlay.motor.success",
@@ -751,7 +751,7 @@ class OBSHandler:
             logger.debug("obs.overlay.motor.hide",
                         message="Hiding motor action overlay")
 
-            visibility_success = await self.set_source_visibility('main', 'MotorOverlay', False)
+            visibility_success = await self.set_source_visibility('main', 'GeneralOverlay', False)
 
             if visibility_success:
                 logger.info("obs.overlay.motor.hide.success",
@@ -764,7 +764,7 @@ class OBSHandler:
             await asyncio.sleep(1)
 
             request_content = {
-                'inputName': 'MotorOverlay',
+                'inputName': 'GeneralOverlay',
                 'inputSettings': {
                     'text': ''
                 }

--- a/helpers/actions.py
+++ b/helpers/actions.py
@@ -212,3 +212,14 @@ class Actions:
         if not self.obs_integration_enabled:
             return
         await self.obs.trigger_warning_overlay(username, message, duration)
+
+    async def trigger_queue_state_overlay(self, message: str, duration: int = 3) -> None:
+        if not self.obs_integration_enabled:
+            return
+        obs = getattr(self, 'obs', None)
+        if obs is None:
+            return
+        try:
+            await obs.trigger_motor_overlay(message, overlay_type='processing', display_duration=duration)
+        except Exception as exc:
+            logger.exception("obs.overlay.queue_state.error", message="Failed to trigger queue state overlay", exc=exc)

--- a/webui/src/pages/DashboardPage.tsx
+++ b/webui/src/pages/DashboardPage.tsx
@@ -102,6 +102,7 @@ export function DashboardPage() {
   }, [location.key]);
 
   const showDeviceWarning = status === 'ok' && queueState?.enabled === true && !queueState?.playback_device_id;
+  const showPausedBanner = status === 'ok' && queueState?.enabled === true && paused;
 
   return (
     <>
@@ -128,6 +129,21 @@ export function DashboardPage() {
                 Make sure Spotify is open (so it can register a device), then go to{' '}
                 <Link to="/settings?dashboard=1">Settings</Link> and select a playback device.
               </div>
+            </div>
+          ) : null}
+
+          {showPausedBanner ? (
+            <div
+              style={{
+                marginTop: 10,
+                border: '1px solid rgba(220, 53, 69, 0.45)',
+                background: 'rgba(220, 53, 69, 0.12)',
+                borderRadius: 10,
+                padding: '10px 12px',
+              }}
+            >
+              <div style={{ fontWeight: 650, marginBottom: 6 }}>Queue is paused</div>
+              <div className="muted">The current song can finish, but new songs will wait until you click Resume.</div>
             </div>
           ) : null}
 


### PR DESCRIPTION
Trigger OBS overlay notifications when queue is paused/resumed in SongRequestService pause_queue and resume_queue methods. Add trigger_queue_state_overlay helper to Actions class that calls obs.trigger_motor_overlay with queue state messages. Rename OBS source from 'MotorOverlay' to 'GeneralOverlay' in obshandler.py to reflect broader usage. Add red-styled paused banner to Dashboard when queue is enabled and paused, informing users that