### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   #push:
   #  branches:


### PR DESCRIPTION
Potential fix for [https://github.com/rndmzd/TipTune/security/code-scanning/1](https://github.com/rndmzd/TipTune/security/code-scanning/1)

In general, this issue is fixed by explicitly restricting the `GITHUB_TOKEN` permissions in the workflow, either at the top level (applies to all jobs) or per job, choosing the least privilege required. Since this CI workflow only checks out code and builds/tests it, the minimal needed permission is `contents: read`.

The best fix here is to add a `permissions:` block at the workflow root (top-level), right after `name: CI` and before `on:`. This will apply to all jobs that don’t override `permissions`, including the `build` job shown. We will set `contents: read`, which is the minimal starting point suggested by CodeQL and is sufficient for `actions/checkout` and the other actions used. No other scopes (like `pull-requests`, `issues`, etc.) appear necessary from the snippet.

Concretely, edit `.github/workflows/ci.yml` around lines 1–4 to insert:

```yaml
permissions:
  contents: read
```

between `name: CI` and `on:`. No imports or additional definitions are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
