### PR TITLE
Add environment variables for backend host/port and improve API error…

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,7 +46,9 @@ pub fn run() {
                 let sidecar_command = app
                     .shell()
                     .sidecar("TipTune")?
-                    .env("TIPTUNE_PARENT_PID", std::process::id().to_string());
+                    .env("TIPTUNE_PARENT_PID", std::process::id().to_string())
+                    .env("TIPTUNE_WEB_HOST", "127.0.0.1")
+                    .env("TIPTUNE_WEB_PORT", "8765");
                 let (mut rx, child) = sidecar_command.spawn()?;
 
                 app.manage(SidecarState(Mutex::new(Some(child))));


### PR DESCRIPTION
… messages

Add TIPTUNE_WEB_HOST and TIPTUNE_WEB_PORT environment variables to sidecar command to explicitly configure backend address. Improve API error handling in apiJson() to provide clearer error messages when backend is unreachable, including specific hints about checking sidecar status and port availability. Distinguish between timeout errors (AbortError) and connection failures with appropriate user-facing messages.