### PR TITLE
Update documentation to reflect unified Spotify/YouTube queue system …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TipTune
 
-TipTune turns tips into queued music requests and provides a local dashboard for playback control, setup, and OBS overlays.
+TipTune turns tips into queued music requests (Spotify and/or YouTube) and provides a local dashboard for playback control, setup, and OBS overlays.
 
 This repo contains:
 
@@ -106,6 +106,8 @@ TipTune uses these sections/keys (see `config.ini.example`):
 
 - `[Spotify]` (required for playback)
   - `client_id`, `redirect_url`, `playback_device_id`
+- `[Music]` (required)
+  - `source` (`spotify` or `youtube`)
 - `[OpenAI]` (optional)
   - `api_key`, `model`
 - `[Events API]` (optional)
@@ -139,6 +141,25 @@ Behavior:
 
 ---
 
+## Music sources
+
+TipTune supports two music sources:
+
+- **Spotify**
+  - Full search + playback control through the Spotify Web API.
+  - Requires Spotify app setup + authorization.
+- **YouTube**
+  - Search + playback via `yt-dlp` and an in-dashboard audio player.
+  - Does not require Spotify credentials.
+
+Choose the default source in:
+
+- `Music.source=spotify|youtube`
+
+You can also override per-tip by including the word `spotify` or `youtube` in the tip message.
+
+---
+
 ## Spotify setup
 
 TipTune controls playback and queues tracks via the Spotify Web API.
@@ -163,6 +184,17 @@ Notes:
 
 - Spotify playback control typically requires Spotify Premium.
 - The redirect URL must be `http` and must use `127.0.0.1` or `localhost` with an explicit port.
+
+---
+
+## YouTube setup
+
+If you want to use YouTube as the music source:
+
+- Set `Music.source=youtube` (Setup Wizard → General Settings).
+- Ensure `yt-dlp` is available in your runtime.
+
+TipTune only streams from allowed YouTube hosts (for example `youtube.com`, `*.youtube.com`, and `youtu.be`).
 
 ---
 

--- a/TipTune.spec
+++ b/TipTune.spec
@@ -41,6 +41,7 @@ def _datas():
     add('scenes.yaml', '.')
     add('config.ini.example', '.')
     add('docs/USER_MANUAL.md', 'docs')
+    add('docs/QUICK_START.md', 'docs')
     add_dir('webui/dist', 'webui/dist')
 
     return items

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -58,7 +58,7 @@ If you need to bypass the redirect temporarily:
 
 ## 3) Spotify: configure + connect
 
-TipTune uses Spotify for search and playback control.
+TipTune can use Spotify for search and playback control.
 
 ### 3.1 Create a Spotify Developer app
 
@@ -142,7 +142,24 @@ In the dashboard:
 
 ---
 
-## 7) (Optional) OBS overlays
+## 7) (Optional) YouTube as your music source
+
+TipTune can also use YouTube for search and playback.
+
+1. In Setup Wizard → **General Settings** (or Settings → Music), set:
+
+   - `Music.source=youtube`
+
+1. Make sure TipTune has `yt-dlp` available in its runtime.
+
+Notes:
+
+- TipTune only streams from allowed YouTube hosts (for example `youtube.com`, `*.youtube.com`, and `youtu.be`).
+- The Dashboard will play YouTube audio using an in-page audio player.
+
+---
+
+## 8) (Optional) OBS overlays
 
 In Settings:
 


### PR DESCRIPTION
…and music source configuration

Add documentation for the new unified queue system that supports both Spotify and YouTube sources. Update README.md to mention both sources in description and add Music sources section explaining Spotify vs YouTube setup and configuration. Add Music.source configuration to config sections and Setup Wizard steps. Update USER_MANUAL.md with "What's changed recently" section covering unified queue, YouTube