### PR TITLE
Add configurable source override option to control whether users can …

### DIFF
--- a/app.py
+++ b/app.py
@@ -1039,6 +1039,12 @@ class SongRequestService:
     def _active_source(self) -> str:
         return _active_music_source()
 
+    def _allow_source_override_in_request_message(self) -> bool:
+        try:
+            return config.getboolean("General", "allow_source_override_in_request_message", fallback=True)
+        except Exception:
+            return True
+
     def _source_override_from_text(self, text: str) -> Optional[str]:
         try:
             msg = text or ''
@@ -2470,7 +2476,7 @@ class SongRequestService:
             if not is_song_request:
                 return
 
-            source_override = self._source_override_from_text(tip_message)
+            source_override = self._source_override_from_text(tip_message) if self._allow_source_override_in_request_message() else None
             source = _normalize_music_source(source_override, default=active_source)
 
             request_count = max(1, self.checks.get_request_count(tip_amount))
@@ -3468,7 +3474,7 @@ class SongRequestService:
             "Spotify": {"client_id", "redirect_url", "playback_device_id"},
             "Search": {"google_api_key", "google_cx"},
             "Music": {"source"},
-            "General": {"song_cost", "skip_song_cost", "multi_request_tips", "request_overlay_duration", "setup_complete", "auto_check_updates", "debug_log_to_file", "debug_log_path"},
+            "General": {"song_cost", "skip_song_cost", "multi_request_tips", "allow_source_override_in_request_message", "request_overlay_duration", "setup_complete", "auto_check_updates", "debug_log_to_file", "debug_log_path"},
             "OBS": {"enabled", "host", "port", "password", "scene_name"},
             "Web": {"host", "port"},
         }

--- a/config.ini.example
+++ b/config.ini.example
@@ -25,6 +25,7 @@ source = spotify
 # General application settings
 song_cost = 27
 multi_request_tips = true
+allow_source_override_in_request_message = true
 skip_song_cost = 51
 request_overlay_duration = 10
 debug_log_to_file = false

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -122,6 +122,7 @@ function tooltip(section: string, key: string) {
     'Music.source': 'Select which music source TipTune will use to fulfill song requests and searches.',
     'General.song_cost': 'Default token cost to request a song.',
     'General.multi_request_tips': 'When enabled, tips that are a multiple of song_cost can request multiple songs. When disabled, only an exact song_cost tip triggers a single request.',
+    'General.allow_source_override_in_request_message': 'When enabled, users can include the word “spotify” or “youtube” in their request message to override the selected Music source for that request.',
     'General.skip_song_cost': 'Token cost to skip the currently playing song.',
     'General.request_overlay_duration': 'How long (in seconds) OBS overlays stay visible after they are shown.',
     'General.debug_log_to_file': 'When enabled, TipTune writes verbose DEBUG logs to a file. Useful for troubleshooting, but can grow quickly.',
@@ -319,6 +320,12 @@ export function SettingsPage() {
     return !(s === 'false' || s === '0' || s === 'no' || s === 'off');
   })();
 
+  const allowSourceOverrideInRequestMessageEnabled = (() => {
+    const raw = v('General', 'allow_source_override_in_request_message');
+    const s = (raw || 'true').trim().toLowerCase();
+    return !(s === 'false' || s === '0' || s === 'no' || s === 'off');
+  })();
+
   const debugLogToFileEnabled = (() => {
     const raw = v('General', 'debug_log_to_file');
     const s = (raw || 'false').trim().toLowerCase();
@@ -386,6 +393,7 @@ export function SettingsPage() {
       General: {
         song_cost: v('General', 'song_cost'),
         multi_request_tips: multiRequestTipsEnabled ? 'true' : 'false',
+        allow_source_override_in_request_message: allowSourceOverrideInRequestMessageEnabled ? 'true' : 'false',
         skip_song_cost: v('General', 'skip_song_cost'),
         request_overlay_duration: v('General', 'request_overlay_duration'),
         auto_check_updates: autoCheckUpdatesEnabled ? 'true' : 'false',
@@ -500,6 +508,27 @@ export function SettingsPage() {
               }
             />
             <span style={{ whiteSpace: 'nowrap' }}>{humanizeKey('multi_request_tips')}</span>
+          </label>
+
+          <label
+            title={tooltip('General', 'allow_source_override_in_request_message')}
+            style={{ display: 'flex', justifyContent: 'flex-start', width: 'fit-content', gap: 6, alignItems: 'center', marginTop: 12 }}
+          >
+            <input
+              type="checkbox"
+              checked={allowSourceOverrideInRequestMessageEnabled}
+              style={{ width: 16, height: 16, padding: 0, margin: 0, flex: '0 0 auto' }}
+              onChange={(e) =>
+                setCfg((c) => ({
+                  ...c,
+                  General: {
+                    ...(c.General || {}),
+                    allow_source_override_in_request_message: e.target.checked ? 'true' : 'false',
+                  },
+                }))
+              }
+            />
+            <span style={{ whiteSpace: 'nowrap' }}>{humanizeKey('allow_source_override_in_request_message')}</span>
           </label>
           <label title={tooltip('General', 'skip_song_cost')}>{humanizeKey('skip_song_cost')}</label>
           <input

--- a/webui/src/pages/SetupPage.tsx
+++ b/webui/src/pages/SetupPage.tsx
@@ -128,6 +128,7 @@ const DEFAULT_CFG: Record<string, Record<string, string>> = {
   General: {
     request_overlay_duration: '10',
     multi_request_tips: 'true',
+    allow_source_override_in_request_message: 'true',
   },
 };
 
@@ -169,6 +170,7 @@ function withDefaults(inputCfg: Record<string, Record<string, string>>): Record<
       ...general,
       request_overlay_duration: norm(general.request_overlay_duration) || DEFAULT_CFG.General.request_overlay_duration,
       multi_request_tips: norm(general.multi_request_tips) || DEFAULT_CFG.General.multi_request_tips,
+      allow_source_override_in_request_message: norm(general.allow_source_override_in_request_message) || DEFAULT_CFG.General.allow_source_override_in_request_message,
     },
   };
 }
@@ -403,6 +405,8 @@ export function SetupPage() {
           General: {
             song_cost: v('General', 'song_cost'),
             multi_request_tips: v('General', 'multi_request_tips') || DEFAULT_CFG.General.multi_request_tips,
+            allow_source_override_in_request_message:
+              v('General', 'allow_source_override_in_request_message') || DEFAULT_CFG.General.allow_source_override_in_request_message,
             skip_song_cost: v('General', 'skip_song_cost'),
             request_overlay_duration: v('General', 'request_overlay_duration'),
             setup_complete: 'true',
@@ -899,6 +903,21 @@ export function SetupPage() {
             <option value="false">false</option>
           </select>
           <div className="muted">If true, multiples of song_cost can request multiple songs in one tip.</div>
+
+          <label>{humanizeKey('allow_source_override_in_request_message')}</label>
+          <select
+            value={(v('General', 'allow_source_override_in_request_message') || DEFAULT_CFG.General.allow_source_override_in_request_message).toLowerCase()}
+            onChange={(e) =>
+              setCfg((c) => ({
+                ...c,
+                General: { ...(c.General || {}), allow_source_override_in_request_message: e.target.value },
+              }))
+            }
+          >
+            <option value="true">true</option>
+            <option value="false">false</option>
+          </select>
+          <div className="muted">If true, users can include “spotify” or “youtube” in their request message to override the music source for that request.</div>
 
           <label>OBS overlay duration</label>
           <input


### PR DESCRIPTION
…specify music source in request messages

Add new `allow_source_override_in_request_message` configuration option (default: true) that controls whether users can include "spotify" or "youtube" in their tip messages to override the configured music source. Add `_allow_source_override_in_request_message()` helper method and update `_source_override_from_text()` call to respect this setting. Add configuration option to config.ini.example,