### PR TITLE
Adds TipTune audio capture status monitoring to OBS integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -1803,12 +1803,23 @@ class SongRequestService:
             return {"enabled": True, "connected": False}
 
         spotify_audio_capture = None
+        tiptune_audio_capture = None
         try:
             spotify_audio_capture = await obs.get_spotify_audio_capture_status(scene_key='main', exe_name='Spotify.exe', scene_name=scene_name or None)
         except Exception:
             spotify_audio_capture = None
+        try:
+            tiptune_audio_capture = await obs.get_app_audio_capture_status(scene_key='main', exe_name='TipTune.exe', scene_name=scene_name or None)
+        except Exception:
+            tiptune_audio_capture = None
 
-        return {"enabled": True, "connected": True, "status": status, "spotify_audio_capture": spotify_audio_capture}
+        return {
+            "enabled": True,
+            "connected": True,
+            "status": status,
+            "spotify_audio_capture": spotify_audio_capture,
+            "tiptune_audio_capture": tiptune_audio_capture,
+        }
 
     async def ensure_obs_text_sources(self) -> Optional[Dict[str, Any]]:
         desired_enabled = config.getboolean("OBS", "enabled", fallback=True) if config.has_section("OBS") else False

--- a/handlers/obshandler.py
+++ b/handlers/obshandler.py
@@ -514,7 +514,7 @@ class OBSHandler:
             'sources': sources,
         }
 
-    async def get_spotify_audio_capture_status(self, scene_key: str = 'main', exe_name: str = 'Spotify.exe', scene_name: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    async def _get_audio_capture_status(self, scene_key: str = 'main', exe_name: str = '', scene_name: Optional[str] = None) -> Optional[Dict[str, Any]]:
         main_scene = self._resolve_scene_name(scene_name=scene_name, scene_key=scene_key)
         inputs = await self._get_inputs()
         if inputs is None:
@@ -562,6 +562,12 @@ class OBSHandler:
             'in_main_scene': bool(in_main_scene),
             'present': bool(input_exists and in_main_scene),
         }
+
+    async def get_spotify_audio_capture_status(self, scene_key: str = 'main', exe_name: str = 'Spotify.exe', scene_name: Optional[str] = None) -> Optional[Dict[str, Any]]:
+        return await self._get_audio_capture_status(scene_key=scene_key, exe_name=exe_name, scene_name=scene_name)
+
+    async def get_app_audio_capture_status(self, scene_key: str = 'main', exe_name: str = '', scene_name: Optional[str] = None) -> Optional[Dict[str, Any]]:
+        return await self._get_audio_capture_status(scene_key=scene_key, exe_name=exe_name, scene_name=scene_name)
 
     async def ensure_spotify_audio_capture(self,
                                           scene_key: str = 'main',

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -48,6 +48,14 @@ type ObsStatusResp = {
     in_main_scene?: boolean;
     present?: boolean;
   } | null;
+  tiptune_audio_capture?: {
+    target_exe?: string;
+    input_name?: string | null;
+    input_kind?: string | null;
+    input_exists?: boolean;
+    in_main_scene?: boolean;
+    present?: boolean;
+  } | null;
 };
 
 type ObsEnsureResp = {
@@ -357,6 +365,7 @@ export function SettingsPage() {
   const obsPasswordPlaceholder = setupStatus?.obs_configured ? '(leave blank to keep)' : '';
 
   const spotifyAudio = obsStatus?.spotify_audio_capture || null;
+  const tiptuneAudio = obsStatus?.tiptune_audio_capture || null;
   const showCreateSpotifyAudio = obsEnabled && !!obsStatus?.enabled && (spotifyAudio ? !spotifyAudio.present : true);
 
   const appVersion = runtimeAppVersion || (typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : '');
@@ -767,6 +776,81 @@ export function SettingsPage() {
                 </tbody>
               </table>
             </div>
+
+            <label style={{ marginTop: 14 }}>TipTune audio capture (YouTube sync)</label>
+            <div className="tableWrap" style={{ marginTop: 8 }}>
+              <table className="dataTable">
+                <thead>
+                  <tr>
+                    <th>Item</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      <code>Application Audio Capture</code>
+                    </td>
+                    <td>
+                      <span className={tiptuneAudio?.present ? 'pill pillSuccess' : 'pill pillError'}>{tiptuneAudio?.present ? 'present' : 'missing'}</span>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className="muted">
+                      Target exe
+                    </td>
+                    <td>{tiptuneAudio?.target_exe || 'TipTune.exe'}</td>
+                  </tr>
+                  <tr>
+                    <td className="muted">
+                      Input exists
+                    </td>
+                    <td>
+                      <span className={tiptuneAudio?.input_exists ? 'pill pillSuccess' : 'pill pillError'}>
+                        {tiptuneAudio?.input_exists ? 'yes' : 'no'}
+                      </span>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className="muted">
+                      In main scene
+                    </td>
+                    <td>
+                      <span className={tiptuneAudio?.in_main_scene ? 'pill pillSuccess' : 'pill pillError'}>
+                        {tiptuneAudio?.in_main_scene ? 'yes' : 'no'}
+                      </span>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className="muted">
+                      Matched input
+                    </td>
+                    <td>
+                      {tiptuneAudio?.input_name ? <code>{tiptuneAudio.input_name}</code> : <span className="muted">(none)</span>}
+                      {tiptuneAudio?.input_kind ? (
+                        <>
+                          {' '}<span className="muted">(</span>
+                          <code>{tiptuneAudio.input_kind}</code>
+                          <span className="muted">)</span>
+                        </>
+                      ) : null}
+                    </td>
+                  </tr>
+                  {!tiptuneAudio ? (
+                    <tr>
+                      <td colSpan={2} className="muted">
+                        (no data)
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+            {tiptuneAudio?.present ? null : (
+              <div className="muted" style={{ marginTop: 8 }}>
+                Create an Application Audio Capture input in OBS targeting TipTune.exe to sync YouTube playback audio.
+              </div>
+            )}
 
             <label style={{ marginTop: 14 }}>Spotify audio capture</label>
             <div className="tableWrap" style={{ marginTop: 8 }}>


### PR DESCRIPTION
Refactors get_spotify_audio_capture_status() into generic _get_audio_capture_status() helper method and introduces get_app_audio_capture_status() wrapper for querying arbitrary executable audio captures. Updates SongRequestService.get_obs_status() to fetch and return tiptune_audio_capture status alongside existing spotify_audio_capture data. Adds TipTune audio capture status table to SettingsPage displaying target exe, input existence