### PR TITLE
Adds server-side YouTube playback pause/resume tracking and stale tra…

### DIFF
--- a/webui/src/components/PlaybackContext.tsx
+++ b/webui/src/components/PlaybackContext.tsx
@@ -308,6 +308,15 @@ export function PlaybackProvider(props: { children: React.ReactNode }) {
       }
       setYoutubePaused(true);
       updateYoutubeDebug('pause');
+      try {
+        await apiJson('/api/playback/pause', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        });
+      } catch {
+      }
+      refresh().catch(() => {});
       return;
     }
     if (!isSpotify) return;
@@ -336,6 +345,15 @@ export function PlaybackProvider(props: { children: React.ReactNode }) {
         }
       }
       updateYoutubeDebug('play');
+      try {
+        await apiJson('/api/playback/resume', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        });
+      } catch {
+      }
+      refresh().catch(() => {});
       return;
     }
     if (!isSpotify) return;


### PR DESCRIPTION
…ck advancement fallback

Implements pause_playback() and resume_playback() support for YouTube tracks by setting _queue_playback_paused state and persisting to disk. Adds server-side fallback in queue monitor that advances YouTube tracks when elapsed time exceeds duration by 10+ seconds to handle cases where frontend audio events don't trigger advancement. Updates PlaybackContext pause/resume handlers to call /api/playback/pause and /